### PR TITLE
fix: nack throwing consumer only if didnt (n)acked

### DIFF
--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -136,7 +136,7 @@ export class Queue {
                     'consumer',
                     new Error(`[BUG] Consumer function of queue ${this.name} throws exception. Message will be rejected. Error: ${stringify(err)}`),
                 );
-                if (this.consumerOptions.noAck === false) {
+                if (this.consumerOptions.noAck === false && !message.isProcessed()) {
                     message.nack(false);
                 }
                 return;


### PR DESCRIPTION
solves issue #16 

Added check of `message.acked` and `message.nacked`. Also updated tests for this change